### PR TITLE
Add support for Filtered Aggregator

### DIFF
--- a/aggregations.go
+++ b/aggregations.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 )
 
-type Aggregation struct {
+type Aggregator struct {
 	Type        string   `json:"type"`
 	Name        string   `json:"name,omitempty"`
 	FieldName   string   `json:"fieldName,omitempty"`
@@ -15,53 +15,68 @@ type Aggregation struct {
 	ByRow       bool     `json:"byRow,omitempty"`
 }
 
+type FilteredAggregator struct {
+	Filter      *Filter       `json:"filter,omitempty"`
+	Aggregator  Aggregator    `json:"aggregator,omitempty"`
+}
+
+type Aggregation struct {
+	Aggregator
+	FilteredAggregator
+}
+
 func AggRawJson(rawJson string) Aggregation {
-	agg := &Aggregation{}
+	agg := &Aggregator{}
 	json.Unmarshal([]byte(rawJson), agg)
-	return *agg
+	return Aggregation{*agg, FilteredAggregator{}}
 }
 
 func AggCount(name string) Aggregation {
-	return Aggregation{
+	agg := Aggregator{
 		Type: "count",
 		Name: name,
 	}
+	return Aggregation{agg, FilteredAggregator{}}
 }
 
 func AggLongSum(name, fieldName string) Aggregation {
-	return Aggregation{
+	agg := Aggregator{
 		Type:      "longSum",
 		Name:      name,
 		FieldName: fieldName,
 	}
+	return Aggregation{agg, FilteredAggregator{}}
 }
 
 func AggDoubleSum(name, fieldName string) Aggregation {
-	return Aggregation{
+	agg := Aggregator{
 		Type:      "doubleSum",
 		Name:      name,
 		FieldName: fieldName,
 	}
+	return Aggregation{agg, FilteredAggregator{}}
 }
 
 func AggMin(name, fieldName string) Aggregation {
-	return Aggregation{
+	agg := Aggregator{
 		Type:      "min",
 		Name:      name,
 		FieldName: fieldName,
 	}
+	return Aggregation{agg, FilteredAggregator{}}
 }
 
 func AggMax(name, fieldName string) Aggregation {
-	return Aggregation{
+	agg := Aggregator{
 		Type:      "max",
 		Name:      name,
 		FieldName: fieldName,
 	}
+	return Aggregation{agg, FilteredAggregator{}}
 }
 
 func AggJavaScript(name, fnAggregate, fnCombine, fnReset string, fieldNames []string) Aggregation {
-	return Aggregation{
+	agg := Aggregator{
 		Type:        "javascript",
 		Name:        name,
 		FieldNames:  fieldNames,
@@ -69,6 +84,7 @@ func AggJavaScript(name, fnAggregate, fnCombine, fnReset string, fieldNames []st
 		FnCombine:   fnCombine,
 		FnReset:     fnReset,
 	}
+	return Aggregation{agg, FilteredAggregator{}}
 }
 
 func AggCardinality(name string, fieldNames []string, byRow ...bool) Aggregation {
@@ -76,10 +92,24 @@ func AggCardinality(name string, fieldNames []string, byRow ...bool) Aggregation
 	if len(byRow) != 0 {
 		isByRow = byRow[0]
 	}
-	return Aggregation{
+	agg := Aggregator{
 		Type:       "cardinality",
 		Name:       name,
 		FieldNames: fieldNames,
 		ByRow:      isByRow,
 	}
+	return Aggregation{agg, FilteredAggregator{}}
+}
+
+func FilteredAgg(filter *Filter, aggregation Aggregation) Aggregation {
+	agg := Aggregator{
+		Type: "filtered",
+	}
+	filterAgg := FilteredAggregator{
+		Filter: filter,
+		// aggregation.Aggregator should be part of FilteredAggregator
+		// since this is a different json property field "aggregator"
+		Aggregator: aggregation.Aggregator,
+	}
+	return Aggregation{agg, filterAgg}
 }


### PR DESCRIPTION
Filtered Aggregator wraps an aggregator with a filter query.
Ex: 
`{
	 "type":"filtered", 
	 "filter":{"type":"selector", "dimension":"resource_type", "value":"service"},
	 "aggregator": {"type":"count", "name":"service_count"}
}
`
Usage: Tetration Inventory count api