### PR TITLE
Adds columns field in QueryScan to support limited projection

### DIFF
--- a/queries.go
+++ b/queries.go
@@ -296,9 +296,11 @@ func (q *QuerySelect) onResponse(content []byte) error {
 type QueryScan struct {
 	QueryType    string                 `json:"queryType"`
 	DataSource   string                 `json:"dataSource"`
+	Columns      []string               `json:"columns"`
 	Intervals    []string               `json:"intervals"`
 	BatchSize    int64                  `json:"batchSize"`
 	Limit        int64                  `json:"limit"`
+	Offset       int64                  `json:"offset"`
 	Order        string                 `json:"order"`
 	Filter       *Filter                `json:"filter,omitempty"`
 	Context      map[string]interface{} `json:"context,omitempty"`


### PR DESCRIPTION
## Description
- Without this columns field any QueryScan operation would return all the columns in the data source.
- Ref: https://druid.apache.org/docs/latest/querying/scan-query.html
- Add offset to support pagination