### PR TITLE
Add Legacy field in Scan Query 

### DIFF
--- a/queries.go
+++ b/queries.go
@@ -305,7 +305,7 @@ type QueryScan struct {
 	Filter       *Filter                `json:"filter,omitempty"`
 	Context      map[string]interface{} `json:"context,omitempty"`
 	ResultFormat string                 `json:"resultFormat,omitempty"`
-	Legacy       bool		    `json:"legacy"`
+	Legacy       bool		    `json:"legacy,omitempty"`
 
 	QueryResult []ScanBlob `json:"-"`
 }

--- a/queries.go
+++ b/queries.go
@@ -305,6 +305,7 @@ type QueryScan struct {
 	Filter       *Filter                `json:"filter,omitempty"`
 	Context      map[string]interface{} `json:"context,omitempty"`
 	ResultFormat string                 `json:"resultFormat,omitempty"`
+	Legacy		 bool					`json:"legacy"`
 
 	QueryResult []ScanBlob `json:"-"`
 }

--- a/queries.go
+++ b/queries.go
@@ -305,7 +305,7 @@ type QueryScan struct {
 	Filter       *Filter                `json:"filter,omitempty"`
 	Context      map[string]interface{} `json:"context,omitempty"`
 	ResultFormat string                 `json:"resultFormat,omitempty"`
-	Legacy		 bool					`json:"legacy"`
+	Legacy       bool		    `json:"legacy"`
 
 	QueryResult []ScanBlob `json:"-"`
 }


### PR DESCRIPTION
This PR is to add Legacy field into Scan Query. Legacy is supported by Druid according to [https://druid.apache.org/docs/latest/querying/scan-query.html#legacy-mode](https://druid.apache.org/docs/latest/querying/scan-query.html#legacy-mode)